### PR TITLE
Fix for the missing Done button in Settings

### DIFF
--- a/Conferences/Conferences/ConferenceList.swift
+++ b/Conferences/Conferences/ConferenceList.swift
@@ -32,7 +32,7 @@ struct ConferenceList: View {
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(maxWidth: 150, maxHeight: 150)
-                    Text("An error occured while fetching information.")
+                    Text("An error occurred while fetching information.")
                 }
                 
                 Spacer()

--- a/Conferences/Settings/SettingsView.swift
+++ b/Conferences/Settings/SettingsView.swift
@@ -14,12 +14,14 @@ struct SettingsView: View {
                     InfoView()
                 }
             }
-        }.toolbar {
-            Button {
-                dismiss()
-            } label: {
-                Text("Done")
+            .toolbar {
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Done")
+                }
             }
+            .navigationTitle("Settings")
         }
     }
 }


### PR DESCRIPTION
The Done button wasn't appearing in the navigation bar, so when the device was in landscape there was no way to dismiss the view.

• Toolbar button is on the List rather than the NavigationView
• Added a "Settings" title for consistency with the other views
• "Occurred" typo fix

![Simulator Screenshot - iPhone 14 Pro - 2023-05-16 at 12 17 28 2](https://github.com/Oliver-Binns/Conferences/assets/1451896/58b07968-3b60-498d-af16-c5ba20576a6f)
