### PR TITLE
chore: fixed linting of conventional commits to ensure non-confirming commits are rejected

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and Test default scheme using any available iPhone simulator

--- a/verify-commit-messages.sh
+++ b/verify-commit-messages.sh
@@ -3,19 +3,17 @@
 FROM="origin/main"
 TO="$(git branch --show-current)"
 
-commits=$(git log --pretty=format:'%h %s' --abbrev-commit --date=relative $FROM..$TO)
+commits=$(git log --pretty=format:'%s' --date=relative $FROM..$TO)
 
 echo $commits
 
 echo $commits |
 while read -r line; do
-  MSG=${line:8}
-
-  check=$(echo $MSG | egrep '^(docs|fix|feat|chore|style|refactor|perf|test)(?:\((.*)\))?(!?)\: (.*)$')
+  check=$(echo $line | egrep '^(docs|fix|feat|chore|style|refactor|perf|test)(?:\((.*)\))?(!?)\: (.*)$')
 
   if [ "" = "$check" ]; then
     echo "Commit Message did not conform to Conventional Commits:"
-    echo "\"$MSG\""
+    echo "\"$line\""
     exit 1
   fi
 done

--- a/verify-commit-messages.sh
+++ b/verify-commit-messages.sh
@@ -3,7 +3,16 @@
 FROM="main"
 TO="$(git branch --show-current)"
 
+echo "test"
+git log
+
+echo "----"
+
 commits=$(git log --pretty=format:'%h %s' --abbrev-commit --date=relative $FROM..$TO)
+
+echo "----"
+echo "commits"
+echo $commits
 
 echo $commits |
 while read -r line; do

--- a/verify-commit-messages.sh
+++ b/verify-commit-messages.sh
@@ -1,17 +1,10 @@
 #!/bin/bash
 
-FROM="main"
+FROM="origin/main"
 TO="$(git branch --show-current)"
-
-echo "test"
-git log
-
-echo "----"
 
 commits=$(git log --pretty=format:'%h %s' --abbrev-commit --date=relative $FROM..$TO)
 
-echo "----"
-echo "commits"
 echo $commits
 
 echo $commits |

--- a/verify-commit-messages.sh
+++ b/verify-commit-messages.sh
@@ -1,21 +1,23 @@
 #!/bin/bash
 
-FROM="origin/main"
-TO="$(git branch --show-current)"
+FROM="origin/$GITHUB_BASE_REF"
+TO="origin/$GITHUB_REF_NAME"
 
 commits=$(git log --pretty=format:'%s' --date=relative $FROM..$TO)
 
+echo "Origin: $TO"
+echo "Target: $FROM"
 echo $commits
 
 echo $commits |
 while read -r line; do
   check=$(echo $line | egrep '^(docs|fix|feat|chore|style|refactor|perf|test)(?:\((.*)\))?(!?)\: (.*)$')
 
-  echo "commit ok: $line"
-
   if [ "" = "$check" ]; then
     echo "Commit Message did not conform to Conventional Commits:"
     echo "\"$line\""
     exit 1
+  else
+    echo "commit ok: $line"
   fi
 done

--- a/verify-commit-messages.sh
+++ b/verify-commit-messages.sh
@@ -3,6 +3,8 @@
 FROM="origin/$GITHUB_BASE_REF"
 TO="origin/$GITHUB_HEAD_REF"
 
+git log --pretty=format:"%h %s" $FROM..$TO
+
 commits=$(git log --date=relative $FROM..$TO --pretty=format:"%s
 ")
 

--- a/verify-commit-messages.sh
+++ b/verify-commit-messages.sh
@@ -4,7 +4,7 @@ FROM="origin/$GITHUB_BASE_REF"
 TO="origin/$GITHUB_HEAD_REF"
 
 git log --pretty=format:"%s" $FROM..$TO |
-while read -r line; do
+while read -r line || [ -n "$line" ]; do
   echo "read line: $line"
 
   check=$(echo $line | egrep '^(docs|fix|feat|chore|style|refactor|perf|test)(?:\((.*)\))?(!?)\: (.*)$')

--- a/verify-commit-messages.sh
+++ b/verify-commit-messages.sh
@@ -3,10 +3,10 @@
 FROM="origin/$GITHUB_BASE_REF"
 TO="origin/$GITHUB_HEAD_REF"
 
-git log --pretty=format:"%s" $FROM..$TO
-
 git log --pretty=format:"%s" $FROM..$TO |
 while read -r line; do
+  echo "read line: $line"
+
   check=$(echo $line | egrep '^(docs|fix|feat|chore|style|refactor|perf|test)(?:\((.*)\))?(!?)\: (.*)$')
 
   if [ "" = "$check" ]; then

--- a/verify-commit-messages.sh
+++ b/verify-commit-messages.sh
@@ -3,7 +3,9 @@
 FROM="main"
 TO="$(git branch --show-current)"
 
-git log --pretty=format:'%h %s' --abbrev-commit --date=relative $FROM..$TO |
+commits=$(git log --pretty=format:'%h %s' --abbrev-commit --date=relative $FROM..$TO)
+
+echo $commits |
 while read -r line; do
   MSG=${line:8}
 

--- a/verify-commit-messages.sh
+++ b/verify-commit-messages.sh
@@ -3,10 +3,9 @@
 FROM="origin/$GITHUB_BASE_REF"
 TO="origin/$GITHUB_HEAD_REF"
 
-commits=$(git log --pretty=format:'%s' --date=relative $FROM..$TO)
+commits=$(git log --date=relative $FROM..$TO --pretty=format:"%s
+")
 
-echo "Origin: $TO"
-echo "Target: $FROM"
 echo $commits
 
 echo $commits |

--- a/verify-commit-messages.sh
+++ b/verify-commit-messages.sh
@@ -5,8 +5,6 @@ TO="origin/$GITHUB_HEAD_REF"
 
 git log --pretty=format:"%s" $FROM..$TO |
 while read -r line || [ -n "$line" ]; do
-  echo "read line: $line"
-
   check=$(echo $line | egrep '^(docs|fix|feat|chore|style|refactor|perf|test)(?:\((.*)\))?(!?)\: (.*)$')
 
   if [ "" = "$check" ]; then

--- a/verify-commit-messages.sh
+++ b/verify-commit-messages.sh
@@ -3,14 +3,9 @@
 FROM="origin/$GITHUB_BASE_REF"
 TO="origin/$GITHUB_HEAD_REF"
 
-git log --pretty=format:"%h %s" $FROM..$TO
+git log --pretty=format:"%s" $FROM..$TO
 
-commits=$(git log --date=relative $FROM..$TO --pretty=format:"%s
-")
-
-echo $commits
-
-echo $commits |
+git log --pretty=format:"%s" $FROM..$TO |
 while read -r line; do
   check=$(echo $line | egrep '^(docs|fix|feat|chore|style|refactor|perf|test)(?:\((.*)\))?(!?)\: (.*)$')
 

--- a/verify-commit-messages.sh
+++ b/verify-commit-messages.sh
@@ -11,6 +11,8 @@ echo $commits |
 while read -r line; do
   check=$(echo $line | egrep '^(docs|fix|feat|chore|style|refactor|perf|test)(?:\((.*)\))?(!?)\: (.*)$')
 
+  echo "commit ok: $line"
+
   if [ "" = "$check" ]; then
     echo "Commit Message did not conform to Conventional Commits:"
     echo "\"$line\""

--- a/verify-commit-messages.sh
+++ b/verify-commit-messages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 FROM="origin/$GITHUB_BASE_REF"
-TO="origin/$GITHUB_REF_NAME"
+TO="origin/$GITHUB_HEAD_REF"
 
 commits=$(git log --pretty=format:'%s' --date=relative $FROM..$TO)
 


### PR DESCRIPTION
Commit messages must follow the conventional commit standard:
<img width="622" alt="image" src="https://github.com/Oliver-Binns/Conferences/assets/5354593/7f3efa55-51fd-42e1-8d6b-0403405ead9f">

If this standard is not followed, the build script will throw an error:
<img width="894" alt="image" src="https://github.com/Oliver-Binns/Conferences/assets/5354593/810288dc-ce0a-4f2f-9f75-e192fab7da2a">

This pull request also introduces the concurrency parameter on the GitHub workflow.
It prevents the overuse of agents by ensuring maximum one build at a time can run for each pull request.
Previous builds will be cancelled if new commits are pushed.