### PR TITLE
chore: exit lane if there are no changes to deploy

### DIFF
--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -45,4 +45,4 @@ jobs:
 
       - name: Cleanup
         run: |
-          rm $CERTIFICATE_PATH
+          [ -e $CERTIFICATE_PATH ] && rm $CERTIFICATE_PATH

--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -45,4 +45,5 @@ jobs:
 
       - name: Cleanup
         run: |
+          CERTIFICATE_PATH="$RUNNER_TEMP/distribution.p12"
           rm -f "$CERTIFICATE_PATH"

--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -45,4 +45,4 @@ jobs:
 
       - name: Cleanup
         run: |
-          [ -e $CERTIFICATE_PATH ] && rm $CERTIFICATE_PATH
+          rm -f "$CERTIFICATE_PATH"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
     fastlane-plugin-semantic_release (1.18.2)
+    fastlane-plugin-versioning (0.5.1)
     gh_inspector (1.1.3)
     google-apis-androidpublisher_v3 (0.44.0)
       google-apis-core (>= 0.11.0, < 2.a)
@@ -215,6 +216,7 @@ PLATFORMS
 DEPENDENCIES
   fastlane
   fastlane-plugin-semantic_release
+  fastlane-plugin-versioning
 
 BUNDLED WITH
    2.2.32

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,7 +19,12 @@ platform :ios do
   desc "Bump Build Number & Deploy to TestFlight"
   lane :on_merge do |options|
     # Increment Build Number	
-    analyze_commits(match: 'beta/*.*.*')
+    is_new_beta = analyze_commits(match: 'beta/*.*.*')
+
+    if !is_new_beta
+      next
+    end
+
     next_version = lane_context[SharedValues::RELEASE_NEXT_VERSION]
     increment_build_number(build_number: next_version)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,13 +26,15 @@ platform :ios do
       next
     end
 
-    next_version = lane_context[SharedValues::RELEASE_NEXT_VERSION]
-    increment_build_number(build_number: next_version)
+    build_number = lane_context[SharedValues::RELEASE_NEXT_VERSION]
+    increment_build_number_in_plist(build_number: build_number)
+    increment_build_number_in_xcodeproj(build_number: build_number)
 
     # Increment Version Number
     analyze_commits(match: '*.*.*')
-    next_version = lane_context[SharedValues::RELEASE_NEXT_VERSION]
-    increment_version_number(version_number: next_version)
+    version_number = lane_context[SharedValues::RELEASE_NEXT_VERSION]
+    increment_version_number_in_plist(version_number: version_number)
+    increment_version_number_in_xcodeproj(version_number: version_number)
 
     # Import Signing Certificate
     password = SecureRandom.hex
@@ -86,7 +88,7 @@ platform :ios do
     end
 
     add_git_tag(
-      grouping: "beta"
+      tag: "beta/" + build_number
     )
     push_git_tags
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,6 +22,7 @@ platform :ios do
     is_new_beta = analyze_commits(match: 'beta/*.*.*')
 
     if !is_new_beta
+      puts "No changes since last deployment. Exiting build."
       next
     end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -85,6 +85,11 @@ platform :ios do
       )
     end
 
+    add_git_tag(
+      grouping: "beta"
+    )
+    push_git_tags
+
     # Upload Build
     notes = conventional_changelog(format: 'plain')
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,3 +3,4 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-semantic_release'
+gem 'fastlane-plugin-versioning'


### PR DESCRIPTION
If no changes (`feat` | `fix`) have been made to the app, then no new deployment occurs.
When deployment occurs, a beta tag is added to Git.